### PR TITLE
Parallelized duration-calculations to avoid blocking forever on first API call made

### DIFF
--- a/src/main/java/com/kevinmost/friendcaster_server/api/FriendCachester.java
+++ b/src/main/java/com/kevinmost/friendcaster_server/api/FriendCachester.java
@@ -36,9 +36,7 @@ public class FriendCachester {
             @Override
             public void onResponse(Response<RssXml> response, Retrofit retrofit) {
                 final RssJson result = response.body().toJSON();
-                for (Episode episode : result.episodeList) {
-                    episode.duration = DurationUtil.getDurationSeconds(episode.mp3Link);
-                }
+                DurationUtil.populateDurations(result);
                 lastUpdatedTimestamp = System.currentTimeMillis();
                 System.err.println("Refreshed cached Friendcast feed");
                 cachedEpisodes = result;

--- a/src/main/java/com/kevinmost/friendcaster_server/util/DurationUtil.java
+++ b/src/main/java/com/kevinmost/friendcaster_server/util/DurationUtil.java
@@ -1,16 +1,31 @@
 package com.kevinmost.friendcaster_server.util;
 
+import com.kevinmost.friendcaster_server.model.RssJson;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.function.Consumer;
 
 import javax.sound.sampled.*;
 
 public class DurationUtil {
-    public static long getDurationSeconds(String urlString) {
+    public static void populateDurations(RssJson json) {
+        json.episodeList.parallelStream()
+                .forEach(episode -> {
+                    episode.duration = getDurationSeconds(episode.mp3Link);
+                });
+    }
+
+    private static long getDurationSeconds(String urlString) {
         try {
             final AudioFileFormat stream = AudioSystem.getAudioFileFormat(new URL(urlString));
-            return Long.parseLong(String.valueOf(stream.properties().get("mp3.id3tag.length"))) / 1000L;
+            final Object lengthTag = stream.properties().get("mp3.id3tag.length");
+            if (lengthTag == null) {
+                // TODO: we need to actually figure out a length here somehow if they don't report it in the ID3 tags
+                return -1L;
+            }
+            return Long.parseLong(String.valueOf(lengthTag)) / 1000L;
         } catch (UnsupportedAudioFileException | IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Actually fixes issue #4 
